### PR TITLE
Add download_audio.sh yt-dlp wrapper, remove download_yt_audio.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # scripts
 
 - `concat_audio.sh` - given a directory containing audio files **_of a single format_**, concatenates the audio to a single file using the same input format. **NB:** files are sorted by however bash defaults; generally the standard bash directory sorting, i.e. symbols > numerical > alphabetical. this was intended to combine dj mixes that have been split into files by track, and relies on track numbers in the file name to order correctly. uses `ffmpeg`
+- `download_audio.sh` - downloads audio from a URL (YouTube, etc.) using `yt-dlp`. extracts at highest quality, keeps best available format (no conversion), and prefers audio-only streams. requires `yt-dlp` and `ffmpeg`. usage: `./download_audio.sh <url>`
 - `extract_video_audio.sh` - extracts audio from a video file using `ffmpeg`. outputs audio as a WAV file to the same dir as the source file using the same name

--- a/download_audio.sh
+++ b/download_audio.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Download audio from URLs at highest quality via yt-dlp.
+# Docs & format selection: https://github.com/yt-dlp/yt-dlp
+
+set -e
+
+if [ -z "$(command -v yt-dlp)" ]; then
+    echo "error: yt-dlp must be installed."
+    exit 1
+fi
+
+if [ -z "$(command -v ffmpeg)" ]; then
+    echo "error: ffmpeg must be installed (required by yt-dlp for audio extraction)."
+    exit 1
+fi
+
+URL=$1
+if [ -z "$URL" ]; then
+    echo "usage: $0 <url>"
+    echo ""
+    echo "Download audio from a URL at the highest quality using yt-dlp."
+    echo "Uses best available audio format (no conversion) and prefers"
+    echo "audio-only streams when available."
+    exit 1
+fi
+
+# -P: save to ~/Downloads (home path).
+# -x: extract audio only (needs ffmpeg/ffprobe).
+# --audio-format best: keep original format, no re-encode (best quality).
+# --audio-quality 0: 0=best, 10=worst (VBR when converting; e.g. mp3/aac).
+# -f format selector (see FORMAT SELECTION in yt-dlp --help):
+#   - Slash "/" = fallback order: left preferred, then right if unavailable.
+#     e.g. "bestaudio/best" = use best audio-only, else best combined.
+#   - "bestaudio" / "ba": best audio-only. "best" / "b": best video+audio.
+#   - Comma "," = download multiple formats. "best.2" = 2nd best.
+#   - Filters: "best[height=720]", "bv*[ext=mp4]+ba[ext=m4a]".
+#   - Merge: "bestvideo+bestaudio" (needs ffmpeg). Presets: -t mp3, -t aac.
+yt-dlp -P ~/Downloads \
+    -x \
+    --audio-format best \
+    --audio-quality 0 \
+    -f 'bestaudio/best' \
+    "$URL"

--- a/download_yt_audio.sh
+++ b/download_yt_audio.sh
@@ -1,6 +1,0 @@
-if [ -z "$1" ]; then
-  echo "Error: No YouTube URL provided. Usage: $0 <youtube_url>" >&2
-  exit 1
-fi
-
-~/Applications/yt-dlp_macos -x --audio-quality 10 --audio-format wav "$1"


### PR DESCRIPTION
## Summary

Adds `download_audio.sh`, a small wrapper around yt-dlp for downloading audio from URLs at highest quality. Replaces and removes `download_yt_audio.sh`.

## Changes

- **`download_audio.sh`** (new):
  - Usage: `./download_audio.sh <url>`
  - Extracts audio only (`-x`), keeps best format (`--audio-format best`), prefers best audio-only streams (`-f 'bestaudio/best'`), `--audio-quality 0`
  - Saves to `~/Downloads` (`-P`)
  - Requires `yt-dlp` and `ffmpeg`; checks both and exits with clear errors if missing
  - Inline comments document `-f` format selector, `/` fallback, filters, merge, presets, and link to [yt-dlp repo](https://github.com/yt-dlp/yt-dlp)
- **`download_yt_audio.sh`**: removed (replaced by `download_audio.sh`)
- **`README.md`**: added `download_audio.sh` to the script list

## Commits

1. Add download_audio.sh + README update
2. Remove download_yt_audio.sh